### PR TITLE
Add workflows to automate versioning, releasing and publishing to npm

### DIFF
--- a/.github/workflows/check-pr-version.yml
+++ b/.github/workflows/check-pr-version.yml
@@ -1,0 +1,26 @@
+name: Check Release Label on PR
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled]
+    branches: [master]
+jobs:
+  check_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Label
+        id: check_label
+        run: echo "LABEL_FOUND=${{contains(github.event.pull_request.labels.*.name, 'major') || contains(github.event.pull_request.labels.*.name, 'minor')  || contains(github.event.pull_request.labels.*.name, 'patch') || contains(github.event.pull_request.labels.*.name, 'no_release')}}" >> $GITHUB_OUTPUT
+
+      - name: No Label Found
+        run: | 
+          echo "::error::missing release label"
+          exit 1
+        if: steps.check_label.outputs.LABEL_FOUND != 'true'
+
+      - name: Add Comment
+        uses: NejcZdovc/comment-pr@v2
+        if: failure()
+        with:
+          message: "**Please add a release label:**<br>**`major`** (for breaking changes), **`minor`** (for new features), **`patch`** (for bug fixes) or **`no_release`** (to skip the auto release process)."
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/check-pr-version.yml
+++ b/.github/workflows/check-pr-version.yml
@@ -1,7 +1,7 @@
-name: Check Release Label on PR
+name: Check Release Label
 on:
   pull_request:
-    types: [opened, labeled, unlabeled]
+    types: [opened, labeled, unlabeled, synchronize]
     branches: [master]
 jobs:
   check_pr:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,4 @@
-name: PR Merge -- Version, Release & Build
+name: Publish New Version
 
 on:
   pull_request:
@@ -14,8 +14,9 @@ jobs:
       # Use a PAT here instead of the default token to ignore branch protection rules. 
       - name: Checkout Master
         uses: actions/checkout@v3
-        ref: master
-        token: ${{ secrets.PAT }}
+        with:
+          ref: master
+          token: ${{ secrets.PAT }}
 
       - name: Bump package.json Version
         id: bump_version

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,48 @@
+name: PR Merge -- Version, Release & Build
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+
+jobs:
+  bump-package-version:
+    # Only run if the PR closed by merging
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    steps:
+      # Use a PAT here instead of the default token to ignore branch protection rules. 
+      - name: Checkout Master
+        uses: actions/checkout@v3
+        ref: master
+        token: ${{ secrets.PAT }}
+
+      - name: Bump package.json Version
+        id: bump_version
+        uses: copapow/version-bump-package@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Commit the new version
+        id: commit_version
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: 'Bump package version (from GitHub Actions Workflow)'
+          tag: ${{ steps.bump_version.outputs.new_version }}
+      
+      - name: Create release on GitHub
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.bump_version.outputs.new_version }}
+          body: ${{ github.event.pull_request.body }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Set up Node.js for NPM
+        uses: actions/setup-node@v1
+        with:
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish package to NPM
+        run:  npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ab-utils",
+  "name": "@digiserve/ab-utils",
   "version": "0.0.0",
   "description": "A common set of utility functions shared by our AppBuilder services",
   "main": "ab-utils.js",


### PR DESCRIPTION
Add workflows to automate versioning, releasing and publishing
- Pull Request expect to be labeled with `major`, `minor`, `patch`, or `no_release`, a check will be run when prs into master are opened.
- Merged Pull Requests with label `major`, `minor`, or `patch` will:
    - Create a new version following semantic versioning. This version is updated in `package.json`, then committed and tagged with git.
   - Create a release on GitHub using the Pull Request Body as release notes
   - Publish to npm `@digiserve/ab-uitls`
   
 The plan is then to use dependabot to ensure dependent repos get the latest version of ab-utils.