### PR TITLE
Hotfix/service request

### DIFF
--- a/utils/serviceRequest.js
+++ b/utils/serviceRequest.js
@@ -104,11 +104,14 @@ class ABServiceRequest extends ServiceCote {
       } catch (err) {
          err._serviceRequest = key;
          err._params = paramStack;
-         this.req.notify.developer(err, {
-            message: `Could not request (${key}) - ${JSON.stringify(
-               paramStack
-            )}`,
-         });
+         if (key != "log_manager.notification") {
+            // If there was an error requesting log_manger.notification, don't use req.notify or we can get caught in an infinite loop
+            this.req.notify.developer(err, {
+               message: `Could not request (${key}) - ${JSON.stringify(
+                  paramStack
+               )}`,
+            });
+         }
          if (callback) return callback(err);
          throw err;
       }

--- a/utils/serviceRequest.js
+++ b/utils/serviceRequest.js
@@ -47,6 +47,7 @@ class ABServiceRequest extends ServiceCote {
     * request(key, data, (err, result) => {})
     */
    async request(key, data, ...args) {
+      if (this.req.performance) this.req.performance.mark(key);
       // handle args
       const callback = args.find((arg) => typeof arg == "function");
       const options = args.find((arg) => typeof arg == "object") ?? {};


### PR DESCRIPTION
- Fix error in `serviceRequest` - call to `performance.mark` was missing so `performanc.measure` threw an error.
- Prevent infinite loop when `serviceRequest` to `log_manager.notification` fails