### PR TITLE
Prevent Port Conflict

### DIFF
--- a/utils/controller.js
+++ b/utils/controller.js
@@ -187,6 +187,7 @@ class ABServiceController extends EventEmitter {
                this.serviceResponder = new cote.Responder({
                   name: this.key,
                   key: this.key,
+                  port: 9000,
                });
             });
          })


### PR DESCRIPTION
OK, so our live NS server is experiencing some condition where two Cote services think they can bind to the same port.  Actually only one can but the other one doesn't know it can't. And this results in the missing messages we've been seeing.

This fix is to force the 2nd listener to start scanning ports at a different port number than the first. 