### PR TITLE
Provide a default `*.healthcheck` request handler for AB services

### DIFF
--- a/utils/controller.js
+++ b/utils/controller.js
@@ -17,6 +17,7 @@ const redis = require("redis");
 // var _ = require("lodash");
 const EventEmitter = require("events").EventEmitter;
 const config = require(path.join(__dirname, "config.js"));
+const DefaultHealthcheck = require("./defaultHealthcheck.js");
 
 const _PendingRequests = {
    /* requestID: cb() */
@@ -71,6 +72,10 @@ class ABServiceController extends EventEmitter {
                }
             }
          });
+      }
+      if (!this.handlers.find(h => h.key.match(/\.healthcheck$/))) {
+         // If no .healthcheck handler was provided, use the default.
+         this.handlers.push(new DefaultHealthcheck(key));
       }
 
       // scan our [ /models, /models/shared ] directories and load our model

--- a/utils/defaultHealthcheck.js
+++ b/utils/defaultHealthcheck.js
@@ -1,0 +1,34 @@
+/**
+ * This will be used to create the default healthcheck request handler for
+ * each AB service. It can be overridden by manually adding a *.healthcheck 
+ * handler to the service.
+ */
+
+module.exports = class DefaultHealthcheck {
+
+   /**
+    *  @param {string} serviceName
+    *     The name/key of the service.
+    */
+   constructor(serviceName) {
+      this.key = `${serviceName}.healthcheck`;
+      this.inputValidation = {};
+   }
+
+   /**
+    * the Request handler.
+    * @param {obj} req
+    * @param {fn} cb
+    *        a node style callback(err, results) to send data when job is finished
+    */
+   fn(req, cb) {
+      try {
+         req.log(`${this.key}: default`);
+         cb(null, "OK");
+      } catch (err) {
+         cb(err);
+      }
+
+   }
+
+};


### PR DESCRIPTION
This will be the default healthcheck service handler that each service uses to respond to the ping sent from api_sails.

I'm not too sure about the label. Is this minor or major?

The api_sails endpoint that sends out the pings is here:
https://github.com/digi-serve/ab_service_api_sails/blob/jc/healthcheck/api/hooks/healthcheck.js
