### PR TITLE
Fix Module Not Found error when using as @digiserve/ab-utils

### DIFF
--- a/shared/models/Role.js
+++ b/shared/models/Role.js
@@ -2,7 +2,7 @@
  * Tenant.js
  * define our DB operations.
  */
-const AB = require("ab-utils");
+const { v4: uuid } = require("uuid");
 
 module.exports = {
    table_name: "site_role",
@@ -12,19 +12,19 @@ module.exports = {
       name: "string",
       users: {
          collection: "User",
-         via: "roles"
+         via: "roles",
       },
 
       userForms: {
          collection: "UserForm",
          via: "roles",
-         dominant: true
-      }
+         dominant: true,
+      },
    },
-   beforeCreate: function(values, cb) {
+   beforeCreate: function (values, cb) {
       if (!values.uuid) {
-         values.uuid = AB.uuid();
+         values.uuid = uuid();
       }
       cb();
-   }
+   },
 };

--- a/shared/models/User.js
+++ b/shared/models/User.js
@@ -2,7 +2,7 @@
  * Tenant.js
  * define our DB operations.
  */
-const AB = require("ab-utils");
+const { v4: uuid } = require("uuid");
 const nanoid = require("nanoid");
 const path = require("path");
 const utils = require(path.join(__dirname, "..", "utils", "utils.js"));
@@ -36,7 +36,7 @@ module.exports = {
    },
    beforeCreate: function (values, cb) {
       if (!values.uuid) {
-         values.uuid = AB.uuid();
+         values.uuid = uuid();
       }
 
       // we generate .token

--- a/shared/models/UserForm.js
+++ b/shared/models/UserForm.js
@@ -4,7 +4,7 @@
  *
  * A UserForm is a request for a User to View some data, and respond to it.
  */
-const AB = require("ab-utils");
+const { v4: uuid } = require("uuid");
 
 module.exports = {
    table_name: "process_userform",
@@ -32,7 +32,7 @@ module.exports = {
       // {json} : the Form.io ui data to be presented as the Form for the user
       //    to interact with.
 
-      data: "json", 
+      data: "json",
       // {json} : the associated data that goes with the Form.io ui
 
       response: "string",
@@ -53,19 +53,19 @@ module.exports = {
 
       roles: {
          collection: "Role",
-         via: "userForms"
+         via: "userForms",
       },
 
       users: {
          collection: "User",
-         via: "userForms"
-      }
+         via: "userForms",
+      },
    },
-   beforeCreate: function(values, cb) {
+   beforeCreate: function (values, cb) {
       if (!values.uuid) {
-         values.uuid = AB.uuid();
+         values.uuid = uuid();
       }
 
       cb();
-   }
+   },
 };


### PR DESCRIPTION
Since we publish to npm as `@digiserve/ab-utils`, we should not rely on requiring `ab-utils`. 
Since we only use `uuid()` just require that directly.