### PR TITLE
[fix] add default 'unhandledrejection' handlers that provide better information

### DIFF
--- a/utils/controller.js
+++ b/utils/controller.js
@@ -10,7 +10,7 @@ const cote = require("cote");
 const fs = require("fs");
 const Mysql = require("mysql");
 const path = require("path");
-const prettyTime = require("pretty-time");
+// const prettyTime = require("pretty-time");
 
 const redis = require("redis");
 
@@ -73,7 +73,7 @@ class ABServiceController extends EventEmitter {
             }
          });
       }
-      if (!this.handlers.find(h => h.key.match(/\.healthcheck$/))) {
+      if (!this.handlers.find((h) => h.key.match(/\.healthcheck$/))) {
          // If no .healthcheck handler was provided, use the default.
          this.handlers.push(new DefaultHealthcheck(key));
       }
@@ -115,6 +115,21 @@ class ABServiceController extends EventEmitter {
          console.info("SIGTERM signal received.");
          this.exit();
       });
+
+      // Setup default error handling for common process errors:
+      this.reqError = this.requestObj({ jobID: `${this.key}.error_handling` });
+      ["unhandledRejection", "uncaughtException", "multipleResolves"].forEach(
+         (type) => {
+            process.on(type, (reason /*, promise */) => {
+               this.reqError.log(`Error: ${type}:`);
+               this.reqError.log(reason.stack);
+               this.reqError.log(reason);
+
+               // Do we exit()?
+               // this.exit();
+            });
+         }
+      );
    }
 
    /**

--- a/utils/reqNotification.js
+++ b/utils/reqNotification.js
@@ -19,7 +19,7 @@ class ABNotification {
     * @param {Error|Error[]|string|object} error
     * @param {object} [info={}]
     */
-   notify(domain, error, info = {}) {
+   async notify(domain, error, info = {}) {
       var serError = this.stringifyErrors(error);
 
       var errStack = new Error("just getting my stack");
@@ -74,17 +74,18 @@ class ABNotification {
       // Also log to the console
       if (typeof this.req.log == "function") {
          this.req.log(jobData);
-      }
-      else if (error instanceof Error) {
+      } else if (error instanceof Error) {
          console.error(jobData);
-      } 
-      else {
+      } else {
          console.log(jobData);
       }
 
-      this.req.serviceRequest("log_manager.notification", jobData, (err) => {
+      try {
+         await this.req.serviceRequest("log_manager.notification", jobData);
+      } catch (err) {
+         this.req.log("Error posting notification:");
          this.req.log(err);
-      });
+      }
    }
 
    stringifyErrors(param) {


### PR DESCRIPTION

Some of our processes experience an 'unhandledrejection' error and modern nodejs apps will auto crash.

We provide some default handlers for these errors and attempt to dump out better debug information that the standard node crash belch.