### PR TITLE
prevent attempts to JSON.parse() an empty string.

### DIFF
--- a/utils/serviceRequest.js
+++ b/utils/serviceRequest.js
@@ -163,7 +163,7 @@ class ABServiceRequest extends ServiceCote {
 
                   // NOTE: our responses are now JSON.stringify()-ed before being
                   // sent, so now we need to .parse() the results
-                  if (typeof results === "string") {
+                  if (typeof results === "string" && results.length > 0) {
                      try {
                         results = JSON.parse(results);
                      } catch (e) {


### PR DESCRIPTION
prevent parsing empty strings.  

This didn't break anything, but just dumped unnecessary error logs in the console.