### PR TITLE
Changes relevant to removing our shared config container

### DIFF
--- a/ab-utils.js
+++ b/ab-utils.js
@@ -10,6 +10,7 @@
 
 const config = require("./utils/config.js");
 const controller = require("./utils/controller.js");
+const defaults = require("./utils/defaults.js");
 const reqApi = require("./utils/reqApi.js");
 const reqService = require("./utils/reqService.js");
 const resApi = require("./utils/resApi.js");
@@ -21,6 +22,7 @@ const { v4: uuid } = require("uuid");
 module.exports = {
    config,
    controller,
+   defaults,
    reqApi,
    reqService,
    resApi,

--- a/utils/config.js
+++ b/utils/config.js
@@ -10,7 +10,16 @@ var _ = require("lodash");
  * @param {string} baseFile should be included as part of the project
  * @returns {object} baseConfig
  */
-module.exports = (baseFile) => {
+module.exports = () => {
+   try {
+      return require(path.join(process.cwd(), "config", "local.js"));
+   } catch (e) {
+      console.error(e);
+      return {};
+   }
+
+   /*
+
    // baseConfig should be included as part of the project
    var baseConfig = {};
    try {
@@ -47,4 +56,5 @@ module.exports = (baseFile) => {
    }
 
    return baseConfig;
+   */
 };

--- a/utils/config.js
+++ b/utils/config.js
@@ -7,12 +7,16 @@
 var path = require("path");
 var _ = require("lodash");
 /**
- * @param {string} baseFile should be included as part of the project
+ * @param {string} key [optional] a subportion of the configs specified
  * @returns {object} baseConfig
  */
-module.exports = () => {
+module.exports = (key) => {
    try {
-      return require(path.join(process.cwd(), "config", "local.js"));
+      var config = require(path.join(process.cwd(), "config", "local.js"));
+      if (key) {
+         return config[key];
+      }
+      return config;
    } catch (e) {
       console.error(e);
       return {};

--- a/utils/controller.js
+++ b/utils/controller.js
@@ -609,6 +609,7 @@ function tryConnect(dbConfig, cb, count = 0) {
    //    DB.destroy();
    // });
    DB.connect(function (err) {
+      DB.destroy();
       if (err) {
          if (count == 0) {
             console.log("mysql not ready ... waiting.");
@@ -621,7 +622,6 @@ function tryConnect(dbConfig, cb, count = 0) {
          return;
       }
       console.log("successful connection to mysql, continuing");
-      DB.destroy();
       cb();
    });
 }

--- a/utils/controller.js
+++ b/utils/controller.js
@@ -73,7 +73,7 @@ class ABServiceController extends EventEmitter {
             }
          });
       }
-      if (!this.handlers.find(h => h.key.match(/\.healthcheck$/))) {
+      if (!this.handlers.find((h) => h.key.match(/\.healthcheck$/))) {
          // If no .healthcheck handler was provided, use the default.
          this.handlers.push(new DefaultHealthcheck(key));
       }
@@ -178,10 +178,11 @@ class ABServiceController extends EventEmitter {
          .then(() => {
             initState = "1.wait_config_complete";
             // make sure the config service has completed:
-            return this._waitForConfig().then(() => {
-               this.config = config(this.key);
-               this.connections = config("datastores");
-            });
+            // return this._waitForConfig().then(() => {
+            let configData = config();
+            this.config = configData[this.key];
+            this.connections = configData["datastores"];
+            // });
          })
          .then(() => {
             initState = "2.wait_redis_ready";
@@ -485,7 +486,10 @@ class ABServiceController extends EventEmitter {
     * @return {Promise}
     */
    _waitForConfig() {
-      return new Promise((resolve /* , reject */) => {
+      return Promise.resolve();
+
+      /*
+      return new Promise((resolve /* , reject * /) => {
          var delay = 500; // ms
          var countTimeout = 40;
          var count = 0;
@@ -506,6 +510,7 @@ class ABServiceController extends EventEmitter {
          }
          setTimeout(waitConfig, delay);
       });
+      */
    }
 
    /**

--- a/utils/defaults.js
+++ b/utils/defaults.js
@@ -1,0 +1,49 @@
+/**
+ * utility functions to help with our initial config values:
+ * @module defaults
+ * @ignore
+ */
+
+/**
+ * @param {string} envKey
+ *                 the specific process.env[key] value we are requesting
+ * @param {multi} defaultValue [optional]
+ *                the value to return if the envKey is not provided.
+ * @returns {multi}
+ */
+function env(envKey, defaultValue) {
+   if (typeof process.env[envKey] == "undefined") {
+      return defaultValue;
+   }
+   try {
+      return JSON.parse(process.env[envKey]);
+   } catch (e) {
+      console.log(e);
+      console.log(process.env[envKey]);
+      return process.env[envKey];
+   }
+}
+
+module.exports = {
+   env,
+   datastores: () => {
+      return {
+         appbuilder: {
+            adapter: "sails-mysql",
+            host: env("MYSQL_HOST", "db"),
+            port: env("MYSQL_PORT", 3306),
+            user: env("MYSQL_USER", "root"),
+            password: process.env.MYSQL_PASSWORD,
+            database: env("MYSQL_DBPREFIX", "appbuilder"),
+         },
+         site: {
+            adapter: "sails-mysql",
+            host: env("MYSQL_HOST", "db"),
+            port: env("MYSQL_PORT", 3306),
+            user: env("MYSQL_USER", "root"),
+            password: process.env.MYSQL_PASSWORD,
+            database: env("MYSQL_DBADMIN", "appbuilder-admin"),
+         },
+      };
+   },
+};

--- a/utils/defaults.js
+++ b/utils/defaults.js
@@ -24,7 +24,7 @@ function env(envKey, defaultValue) {
       let expectedValues = ["http"];
       let isExpected = false;
       expectedValues.forEach((v) => {
-         if (process.env[envKey].indexOf("http") == -1) {
+         if (process.env[envKey].indexOf("http") != -1) {
             isExpected = true;
          }
       });

--- a/utils/defaults.js
+++ b/utils/defaults.js
@@ -18,8 +18,22 @@ function env(envKey, defaultValue) {
    try {
       return JSON.parse(process.env[envKey]);
    } catch (e) {
-      console.log(e);
-      console.log(`process.env[${envKey}]=[${process.env[envKey]}]`);
+      // NOT all of our env variables can be JSON.parsed()
+      // we expect some of these values to error out
+      // no need to report them:
+      let expectedValues = ["http"];
+      let isExpected = false;
+      expectedValues.forEach((v) => {
+         if (process.env[envKey].indexOf("http") == -1) {
+            isExpected = true;
+         }
+      });
+      if (!isExpected) {
+         // let's report this just in case:
+         console.log(e);
+         console.log(`process.env[${envKey}]=[${process.env[envKey]}]`);
+      }
+
       return process.env[envKey];
    }
 }

--- a/utils/defaults.js
+++ b/utils/defaults.js
@@ -19,7 +19,7 @@ function env(envKey, defaultValue) {
       return JSON.parse(process.env[envKey]);
    } catch (e) {
       console.log(e);
-      console.log(process.env[envKey]);
+      console.log(`process.env[${envKey}]=[${process.env[envKey]}]`);
       return process.env[envKey];
    }
 }

--- a/utils/defaults.js
+++ b/utils/defaults.js
@@ -12,7 +12,7 @@
  * @returns {multi}
  */
 function env(envKey, defaultValue) {
-   if (typeof process.env[envKey] == "undefined") {
+   if (typeof process.env[envKey] == "undefined" || process.env[envKey] == "") {
       return defaultValue;
    }
    try {

--- a/utils/reqValidation.js
+++ b/utils/reqValidation.js
@@ -36,7 +36,7 @@ class ABRequestValidation {
          this.__validationErrors.forEach((e) => {
             e.details.forEach((d) => {
                this.req.log(
-                  `... validation error: ${d.message} (${
+                  `... validation error [${this.req.jobID}]: ${d.message} (${
                      d.context.label
                   } : ${JSON.stringify(d.context.value)})`
                );


### PR DESCRIPTION
These changes are for our containers to no longer require the shared Config container.

Our services now look for a local `config/local.js` file that defaults to settings from our ENV.