### PR TITLE
fix converting otel attribute to sentry op

### DIFF
--- a/utils/telemetrySentry.js
+++ b/utils/telemetrySentry.js
@@ -28,8 +28,8 @@ class TelemetrySentry extends TelemetryOpenTelemetry {
          normalizeDepth: 5,
          beforeSendTransaction: (transaction) => {
             // convert open telemetry attribute ("op") to the location sentry expects it
-            transaction.contexts.trace.op = transaction.contexts.trace.data.op;
-            delete transaction.contexts.trace.data.op;
+            transaction.contexts.trace.op =
+               transaction.contexts.otel?.attributes?.op;
             transaction.spans.forEach((span) => {
                span.op = span.data.op;
                delete span.data.op;


### PR DESCRIPTION
## Release Notes
<!-- #release_notes -->
- fix converting the open telemetry span attribute to sentry
<!-- /release_notes --> 
