### PR TITLE
Create a default version check handler

### DIFF
--- a/ab-utils.js
+++ b/ab-utils.js
@@ -1,5 +1,5 @@
 /**
- * a set of common utilities shared by each of our microsservices
+ * a set of common utilities shared by each of our micro-services
  * @module ab-utils
  * @borrows module:config as config
  * @borrows module:Controller as controller

--- a/test/unit/resAPI.test.js
+++ b/test/unit/resAPI.test.js
@@ -29,7 +29,7 @@ describe("ABResponseAPI", () => {
          assert(sailsRes.send.calledOnce);
          assert.equal(
             sailsRes.send.firstCall.firstArg,
-            `{"status":"error","data":"${strErr}","message":"test"}`
+            `{"status":"error","jobID":"??","data":"${strErr}","message":"test"}`
          );
       });
 

--- a/utils/controller.js
+++ b/utils/controller.js
@@ -52,7 +52,7 @@ setInterval(() => {
             entries.push(
                `[${e.jobID}]: [${
                   e.label || e.handler
-               }] [${timeInProcess}]ms D[${e.duplicates.length}] ${e.status}`,
+               }] [${timeInProcess}]ms D[${e.duplicates.length}] ${e.status}`
             );
          }
       });
@@ -151,7 +151,7 @@ class ABServiceController extends EventEmitter {
                      this.haveModels = true;
                   } catch (e) {
                      console.log(
-                        `Error loading model[${pathModels}][${fileName}]:`,
+                        `Error loading model[${pathModels}][${fileName}]:`
                      );
                      console.log("::", e);
                   }
@@ -201,7 +201,7 @@ class ABServiceController extends EventEmitter {
             return new Promise((resolve, reject) => {
                var reqShutdown = ABRequest(
                   { jobID: `${this.key}.before_shutdown` },
-                  this,
+                  this
                );
                var allFNs = [];
                this._beforeShutdown.forEach((f) => {
@@ -302,7 +302,7 @@ class ABServiceController extends EventEmitter {
             return new Promise((resolve, reject) => {
                var reqStartup = ABRequest(
                   { jobID: `${this.key}.after_startup` },
-                  this,
+                  this
                );
                var allStartups = [];
                this._afterStartup.forEach((f) => {
@@ -326,7 +326,7 @@ class ABServiceController extends EventEmitter {
          .catch((err) => {
             var reqErrorStartup = ABRequest(
                { jobID: `${this.key}.error_startup` },
-               this,
+               this
             );
             reqErrorStartup.notify.developer(err, { initState });
          });
@@ -509,7 +509,7 @@ class ABServiceController extends EventEmitter {
 
                // update the stored cb()
                _JobStatus[abReq.requestID].duplicates.push(
-                  _PendingRequests[abReq.requestID],
+                  _PendingRequests[abReq.requestID]
                );
                _PendingRequests[abReq.requestID] = cb;
                return;
@@ -576,7 +576,7 @@ class ABServiceController extends EventEmitter {
                   try {
                      const strResponse = await this.worker(
                         (json) => JSON.stringify(json),
-                        [data],
+                        [data]
                      );
 
                      abReq.performance.measure("worker.JSON.stringify");

--- a/utils/controller.js
+++ b/utils/controller.js
@@ -176,16 +176,19 @@ class ABServiceController extends EventEmitter {
       // Setup default error handling for common process errors:
       this.reqError = this.requestObj({ jobID: `${this.key}.error_handling` });
       ["unhandledRejection", "uncaughtException", "multipleResolves"].forEach(
-         (type) => {
-            process.on(type, (reason /*, promise */) => {
-               this.reqError.log(`Error: ${type}:`);
-               this.reqError.log(reason.stack);
-               this.reqError.log(reason);
+         (handle) => {
+            process.on(handle, (type, promise, reason) => {
+               this.reqError.log(`Error: ${handle}:`);
+               if (type) this.reqError.log(type);
+
+               if (promise) this.reqError.log(promise);
+
+               if (reason) this.reqError.log(reason);
 
                // Do we exit()?
                // this.exit();
             });
-         },
+         }
       );
 
       this._pool = workerpool.pool();

--- a/utils/defaultHealthcheck.js
+++ b/utils/defaultHealthcheck.js
@@ -11,10 +11,12 @@ class DefaultHealthcheck {
     *  @param {string} serviceName
     *     The name/key of the service.
     */
-   constructor(serviceName) {
-      this.key = `${serviceName}.healthcheck`;
+   constructor(controller) {
+      this.key = `${controller.key}.healthcheck`;
       this.inputValidation = {};
    }
+
+   static keyCheck = /\.healthcheck$/;
 
    /**
     * the Request handler.

--- a/utils/handlerVersion.js
+++ b/utils/handlerVersion.js
@@ -1,0 +1,40 @@
+/**
+ * This will be used to display the current controller's version information
+ * in the console log.
+ *
+ * Currently this is used in our testing environment to help in our debugging.
+ * @module
+ * @ignore
+ */
+
+class DefaultVersionHandler {
+   /**
+    *  @param {string} serviceName
+    *     The name/key of the service.
+    */
+   constructor(controller) {
+      this.controller = controller;
+      this.key = `${controller.key}.versioncheck`;
+
+      this.inputValidation = {};
+   }
+
+   static keyCheck = /\.versioncheck/;
+
+   /**
+    * the Request handler.
+    * @param {obj} req
+    * @param {fn} cb
+    *        a node style callback(err, results) to send data when job is finished
+    */
+   fn(req, cb) {
+      try {
+         req.log(`>>> ${this.controller.key} v${this.controller.version}`);
+         cb(null, `"${this.controller.version}"`);
+      } catch (err) {
+         cb(err);
+      }
+   }
+}
+
+module.exports = DefaultVersionHandler;

--- a/utils/resApi.js
+++ b/utils/resApi.js
@@ -25,6 +25,8 @@ class ABResponseAPI {
 
       var packet = {
          status: "error",
+         // include jobID on error messages to provide better debugging
+         jobID: this.req.jobID || "??",
          data: err.toString?.() ?? {},
       };
 

--- a/utils/serviceRequest.js
+++ b/utils/serviceRequest.js
@@ -170,7 +170,10 @@ class ABServiceRequest extends ServiceCote {
                      !options.stringResult
                   ) {
                      try {
-                        results = JSON.parse(results);
+                        // prevent special case: OK from healthcheck
+                        if (results != "OK") {
+                           results = JSON.parse(results);
+                        }
                      } catch (e) {
                         console.log("+++++++++++++++++++++++++++++++");
                         console.error(e);


### PR DESCRIPTION
These additions are related to making it easier to debug our failed e2e tests.  This default handler allows us to print out the specific versions of our services that are running.

## Release Notes
<!-- #release_notes -->
- [wip] add a default versionCheck handler
- [wip] eslint changes
- [wip] include jobID on error responses
- [wip] prevent json parse attempts on default healthCheck responses
<!-- /release_notes --> 
