### PR TITLE
Switch to an App Install Token

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,9 +11,9 @@ jobs:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
     steps:
-      # Use a PAT here instead of the default token to ignore branch protection rules. 
+      # Use a PAT here instead of the default token to ignore branch protection rules.
       - name: Checkout Master
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
           token: ${{ secrets.PAT }}
@@ -23,23 +23,23 @@ jobs:
         uses: copapow/version-bump-package@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Commit the new version
         id: commit_version
         uses: EndBug/add-and-commit@v9
         with:
           message: 'Bump package version (from GitHub Actions Workflow)'
           tag: ${{ steps.bump_version.outputs.new_version }}
-      
+
       - name: Create release on GitHub
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.bump_version.outputs.new_version }}
           body: ${{ github.event.pull_request.body }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Set up Node.js for NPM
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           registry-url: "https://registry.npmjs.org"
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,12 +11,19 @@ jobs:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
     steps:
-      # Use a PAT here instead of the default token to ignore branch protection rules.
+      # We need a App Token here to commit, ignoring the branch protection rules
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.GS_DEV_APP_ID }}
+          private-key: ${{ secrets.GS_DEV_APP_PK }}
+
       - name: Checkout Master
         uses: actions/checkout@v4
         with:
           ref: master
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Bump package.json Version
         id: bump_version


### PR DESCRIPTION
## Release Notes
<!-- #release_notes -->
- Workflow uses app install token rather than a personal auth token
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
