### PR TITLE
Fix wait redis

### DIFF
--- a/utils/controller.js
+++ b/utils/controller.js
@@ -726,43 +726,46 @@ class ABServiceController extends EventEmitter {
     * @return {Promise}
     */
    _waitForRedis() {
-      return new Promise((resolve /* , reject */) => {
-         var client = redis.createClient({
-            host: "redis",
-            // port: <port>,
-            // password: '<password>'
-
-            retry_strategy: function (options) {
-               // if (options.error && options.error.code === "ECONNREFUSED") {
-               //    // End reconnecting on a specific error and flush all commands with
-               //    // a individual error
-               //    return new Error("The server refused the connection");
-               // }
-               // if (options.total_retry_time > 1000 * 60 * 60) {
-               //    // End reconnecting after a specific timeout and flush all commands
-               //    // with a individual error
-               //    return new Error("Retry time exhausted");
-               // }
-               // if (options.attempt > 10) {
-               //    // End reconnecting with built in error
-               //    return undefined;
-               // }
-
-               // console.log("... waiting for redis attempt:" + options.attempt);
-               // reconnect after
-               return Math.min(options.attempt * 200, 3000);
-            },
-         });
-
-         // client.on("error", (err) => {
-         //    console.log("... waiting for redis");
-         // });
-
-         client.on("connect", () => {
-            client.quit();
-            resolve();
-         });
-      });
+      // Can't have a hard coded host for ecs. Is this even necessary, I think
+      // cote can handle
+      return new Promise((r) => r());
+      // return new Promise((resolve /* , reject */) => {
+      //    var client = redis.createClient({
+      //       host: "redis",
+      //       // port: <port>,
+      //       // password: '<password>'
+      //
+      //       retry_strategy: function (options) {
+      //          // if (options.error && options.error.code === "ECONNREFUSED") {
+      //          //    // End reconnecting on a specific error and flush all commands with
+      //          //    // a individual error
+      //          //    return new Error("The server refused the connection");
+      //          // }
+      //          // if (options.total_retry_time > 1000 * 60 * 60) {
+      //          //    // End reconnecting after a specific timeout and flush all commands
+      //          //    // with a individual error
+      //          //    return new Error("Retry time exhausted");
+      //          // }
+      //          // if (options.attempt > 10) {
+      //          //    // End reconnecting with built in error
+      //          //    return undefined;
+      //          // }
+      //
+      //          // console.log("... waiting for redis attempt:" + options.attempt);
+      //          // reconnect after
+      //          return Math.min(options.attempt * 200, 3000);
+      //       },
+      //    });
+      //
+      //    // client.on("error", (err) => {
+      //    //    console.log("... waiting for redis");
+      //    // });
+      //
+      //    client.on("connect", () => {
+      //       client.quit();
+      //       resolve();
+      //    });
+      // });
    }
 }
 

--- a/utils/controller.js
+++ b/utils/controller.js
@@ -14,7 +14,7 @@ const Mysql = require("mysql");
 const path = require("path");
 // const prettyTime = require("pretty-time");
 
-const redis = require("redis");
+// const redis = require("redis");
 
 // var _ = require("lodash");
 const EventEmitter = require("events").EventEmitter;

--- a/utils/defaults.js
+++ b/utils/defaults.js
@@ -51,6 +51,7 @@ module.exports = {
             user: env("MYSQL_USER", "root"),
             password: process.env.MYSQL_PASSWORD,
             database: env("MYSQL_DBPREFIX", "appbuilder"),
+            poolMax: env("MYSQL_POOL_MAX"),
          },
          site: {
             adapter: "sails-mysql",
@@ -59,6 +60,7 @@ module.exports = {
             user: env("MYSQL_USER", "root"),
             password: process.env.MYSQL_PASSWORD,
             database: env("MYSQL_DBADMIN", "appbuilder-admin"),
+            poolMax: env("MYSQL_POOL_MAX"),
          },
       };
    },

--- a/utils/defaults.js
+++ b/utils/defaults.js
@@ -51,7 +51,9 @@ module.exports = {
             user: env("MYSQL_USER", "root"),
             password: process.env.MYSQL_PASSWORD,
             database: env("MYSQL_DBPREFIX", "appbuilder"),
-            poolMax: env("MYSQL_POOL_MAX"),
+            poolMax: env("MYSQL_POOL_MAX")
+               ? parseInt(env("MYSQL_POOL_MAX"))
+               : undefined,
          },
          site: {
             adapter: "sails-mysql",
@@ -60,7 +62,9 @@ module.exports = {
             user: env("MYSQL_USER", "root"),
             password: process.env.MYSQL_PASSWORD,
             database: env("MYSQL_DBADMIN", "appbuilder-admin"),
-            poolMax: env("MYSQL_POOL_MAX"),
+            poolMax: env("MYSQL_POOL_MAX")
+               ? parseInt(env("MYSQL_POOL_MAX"))
+               : undefined,
          },
       };
    },

--- a/utils/defaults.js
+++ b/utils/defaults.js
@@ -15,6 +15,7 @@ function env(envKey, defaultValue) {
    if (typeof process.env[envKey] == "undefined" || process.env[envKey] == "") {
       return defaultValue;
    }
+   if (envKey.startsWith("MYSQL_")) return process.env[envKey];
    try {
       return JSON.parse(process.env[envKey]);
    } catch (e) {
@@ -24,14 +25,15 @@ function env(envKey, defaultValue) {
       let expectedValues = ["http"];
       let isExpected = false;
       expectedValues.forEach((v) => {
-         if (process.env[envKey].indexOf("http") != -1) {
+         if (process.env[envKey].indexOf(v) != -1) {
             isExpected = true;
          }
       });
       if (!isExpected) {
          // let's report this just in case:
-         console.log(e);
-         console.log(`process.env[${envKey}]=[${process.env[envKey]}]`);
+         console.log(
+            `Failed to parse process.env[${envKey}]=[${process.env[envKey]}] as JSON, is this expected?`,
+         );
       }
 
       return process.env[envKey];


### PR DESCRIPTION
- Updates cotejs - they changed there underlying redis library.
- Currently the controller startup waits for a a connection with `http://redis` which works in our docker environment but not `ecs`. We could check using our `COTE_DISCOVERY*` params, but since this is an elasticache service it probably unnecessary. Maybe a skip param?